### PR TITLE
Support installing in org namespace with child apps in cluster namespace

### DIFF
--- a/helm/default-apps-openstack/templates/_helpers.tpl
+++ b/helm/default-apps-openstack/templates/_helpers.tpl
@@ -26,7 +26,7 @@ app.kubernetes.io/managed-by: {{ .Release.Name | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 giantswarm.io/cluster: {{ .Values.cluster.name | quote }}
-giantswarm.io/organization: {{ .Values.cluster.organization | quote }}
+giantswarm.io/organization: {{ .Values.organization.name | quote }}
 giantswarm.io/service-type: managed
 {{- end -}}
 
@@ -37,12 +37,12 @@ kubeConfig:
   inCluster: false
   secret:
     name: {{ .Values.cluster.name }}-kubeconfig
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.organization.namespace }}
 {{- end -}}
 
 {{- define "config" -}}
 config:
   configMap:
     name: {{ .Values.cluster.name }}-cluster-values
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.cluster.namespace }}
 {{- end -}}

--- a/helm/default-apps-openstack/templates/calico.yaml
+++ b/helm/default-apps-openstack/templates/calico.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-calico
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}
   {{- include "config" . | nindent 2 }}
-  name: calico-app
+  name: calico
   namespace: kube-system
   version: 0.2.0

--- a/helm/default-apps-openstack/templates/cert-exporter.yaml
+++ b/helm/default-apps-openstack/templates/cert-exporter.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-cert-exporter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}

--- a/helm/default-apps-openstack/templates/chart-operator.yaml
+++ b/helm/default-apps-openstack/templates/chart-operator.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-chart-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}

--- a/helm/default-apps-openstack/templates/cloud-provider-openstack.yaml
+++ b/helm/default-apps-openstack/templates/cloud-provider-openstack.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-cloud-provider-openstack
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}
   {{- include "config" . | nindent 2 }}
     secret:
       name: {{ .Values.cluster.name }}-cluster-values
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ .Values.cluster.namespace }}
   name: cloud-provider-openstack-app
   namespace: kube-system
   version: 0.1.1

--- a/helm/default-apps-openstack/templates/kube-state-metrics.yaml
+++ b/helm/default-apps-openstack/templates/kube-state-metrics.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-kube-state-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}

--- a/helm/default-apps-openstack/templates/metrics-server.yaml
+++ b/helm/default-apps-openstack/templates/metrics-server.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-metrics-server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}

--- a/helm/default-apps-openstack/templates/net-exporter.yaml
+++ b/helm/default-apps-openstack/templates/net-exporter.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-net-exporter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}

--- a/helm/default-apps-openstack/templates/node-exporter.yaml
+++ b/helm/default-apps-openstack/templates/node-exporter.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ .Values.cluster.name }}-node-exporter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.cluster.namespace }}
 spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -1,6 +1,10 @@
 cluster:
   name: ""
-  organization: ""
+  namespace: ""
+
+organization:
+  name: ""
+  namespace: ""
 
 appOperator:
   version: 5.2.0


### PR DESCRIPTION
This PR:

- Allows the default-apps-openstack app to be installed in the organization namespace while the child apps are installed in the cluster namespace. This is currently required because the WC kubeconfig is in the organization namespace while the cluster-values are in the cluster namespace.

Example `values.yaml`:
```
cluster:
  name: thomas40
  namespace: thomas40

organization:
  name: giantswarm-2
  namespace: org-giantswarm-2

appOperator:
  version: 5.2.0
```

### Testing

- [x] Fresh install works.

Not adding a changelog as there haven't been any releases yet.