### PR TITLE
Remove -app suffix from calico app name

### DIFF
--- a/helm/default-apps-openstack/templates/calico.yaml
+++ b/helm/default-apps-openstack/templates/calico.yaml
@@ -11,6 +11,6 @@ spec:
   catalog: default
   {{- include "kubeconfig" . | nindent 2 }}
   {{- include "config" . | nindent 2 }}
-  name: calico-app
+  name: calico
   namespace: kube-system
   version: 0.2.0


### PR DESCRIPTION
This PR:

- Fixes calico app name to remove `-app` suffix.

### Testing

- [x] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
