### PR TITLE
Push to giantswarm-catalog instead of default-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ workflows:
           context: "architect"
           executor: "app-build-suite"
           name: "package and push default-apps-openstack chart"
-          app_catalog: "default-catalog"
-          app_catalog_test: "default-test-catalog"
+          app_catalog: "giantswarm-catalog"
+          app_catalog_test: "giantswarm-test-catalog"
           chart: "default-apps-openstack"
           # Trigger job on git tag.
           filters:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/586 and https://github.com/giantswarm/roadmap/issues/741

This PR:

- Pushes the app to the giantswarm-catalog instead of the default-catalog.

### Testing

- [x] Fresh install works.
