### PR TITLE
Upgrade `calico-app` to 0.2.1 to enable Felix metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgrade `calico-app` to 0.2.1 to enable Felix metrics.
 - Upgrade `cloud-provider-openstack` to version 0.2.0
 
 ## [0.1.0] - 2022-01-25

--- a/helm/default-apps-openstack/templates/calico.yaml
+++ b/helm/default-apps-openstack/templates/calico.yaml
@@ -13,4 +13,4 @@ spec:
   {{- include "config" . | nindent 2 }}
   name: calico
   namespace: kube-system
-  version: 0.2.0
+  version: 0.2.1


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/725