### PR TITLE
Pass cluster tag to cloud-provider-openstack apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade `calico-app` to 0.2.1 to enable Felix metrics.
 - Upgrade `cloud-provider-openstack` to version 0.2.0.
 - Restrict provider to `openstack`.
+- Pass cluster tag to cloud-provider-openstack apps.
 
 ## [0.1.0] - 2022-01-25
 

--- a/helm/default-apps-openstack/templates/cloud-provider-openstack.yaml
+++ b/helm/default-apps-openstack/templates/cloud-provider-openstack.yaml
@@ -16,4 +16,25 @@ spec:
       namespace: {{ .Release.Namespace }}
   name: cloud-provider-openstack-app
   namespace: kube-system
-  version: 0.2.0
+  userConfig:
+    configMap:
+      name: {{ .Values.clusterName }}-cloud-provider-openstack-user-values
+      namespace: {{ .Release.Namespace }}
+  version: 0.2.2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: {{ .Values.clusterName }}-cloud-provider-openstack-user-values
+  namespace: {{ .Release.Namespace }}
+data:
+  values: |
+    openstack-cinder-csi:
+      clusterID: giant_swarm_cluster_{{ .Values.managementCluster }}_{{ .Values.clusterName }}
+    openstack-cloud-controller-manager:
+      controllerExtraArgs: |-
+        - --cluster-name=giant_swarm_cluster_{{ .Values.managementCluster }}_{{ .Values.clusterName }}
+
+

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -1,2 +1,3 @@
 clusterName: ""
 organization: ""
+managementCluster: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/710

To be able to track openstack resources created by cluster apps
in worklaod clusters, we need to pass cluster tag to apps.

```
cluster tag = giant_swarm_cluster_<management-cluster-name>_<worklaod-cluster-name>
```

### Testing

- [x] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
