### PR TITLE
Restore cluster name/ID values for cloud-provider-openstack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move app definitions to `values.yaml`.
+- Update `cert-exporter` from v2.0.0 to v2.1.0.
+- Update `kube-state-metrics` to v1.5.1 to v1.7.0.
+- Update `metrics-server` from v1.5.0 to v1.6.0.
+- Update `node-exporter` from v1.8.0 to v1.9.0.
 
 ## [0.1.1] - 2022-02-16
 

--- a/helm/default-apps-openstack/templates/apps.yaml
+++ b/helm/default-apps-openstack/templates/apps.yaml
@@ -50,7 +50,7 @@ spec:
   {{- end }}
   {{- end }}
   name: {{ .chartName }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ .namespace }}
   version: {{ .version }}
 {{- with (get $.Values.userConfig $key) }}
 {{- if .configMap }}

--- a/helm/default-apps-openstack/templates/apps.yaml
+++ b/helm/default-apps-openstack/templates/apps.yaml
@@ -63,7 +63,7 @@ metadata:
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
   namespace: {{ $.Release.Namespace }}
 data:
-  {{- .configMap | toYaml | toString | nindent 2 }}
+  {{- (tpl (.configMap | toYaml | toString) $) | nindent 2 }}
 {{- end }}
 {{- if .secret }}
 ---
@@ -75,7 +75,7 @@ metadata:
   name: {{ $.Values.clusterName }}-{{ $appName }}-user-values
   namespace: {{ $.Release.Namespace }}
 stringData:
-  {{ .secret | indent 2 }}
+  {{- (tpl (.secret | toYaml | toString) $) | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -3,11 +3,19 @@ organization: ""
 managementCluster: ""
 
 userConfig:
+  cloudProviderOpenstack:
+    configMap:
+      values: |
+        openstack-cinder-csi:
+          clusterID: giant_swarm_cluster_{{ .Values.managementCluster }}_{{ .Values.clusterName }}
+        openstack-cloud-controller-manager:
+          controllerExtraArgs: |-
+            - --cluster-name=giant_swarm_cluster_{{ .Values.managementCluster }}_{{ .Values.clusterName }}
   netExporter:
     configMap:
       values: |
         dns:
-          service: "kube-dns"
+          service: kube-dns
 
 apps:
   calico:


### PR DESCRIPTION
Improvements from #20 were lost in #16.

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.

Truncated sample output:
```
helm template thomas1-default-apps -n org-multi-project helm/default-apps-openstack --values values-test.yml
---
# Source: default-apps-openstack/templates/apps.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/name: default-apps-openstack
    app.kubernetes.io/instance: "thomas1-default-apps"
    app.kubernetes.io/managed-by: "thomas1-default-apps"
    app.kubernetes.io/version: "0.1.0"
    helm.sh/chart: "default-apps-openstack-0.1.0"
    giantswarm.io/cluster: "thomas1"
    giantswarm.io/organization: "multi-project"
    giantswarm.io/service-type: managed
  name: thomas1-cloud-provider-openstack-user-values
  namespace: org-multi-project
data:
  values: |
    openstack-cinder-csi:
      clusterID: giant_swarm_cluster_gamma_thomas1
    openstack-cloud-controller-manager:
      controllerExtraArgs: |-
        - --cluster-name=giant_swarm_cluster_gamma_thomas1
---
# Source: default-apps-openstack/templates/apps.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/name: default-apps-openstack
    app.kubernetes.io/instance: "thomas1-default-apps"
    app.kubernetes.io/managed-by: "thomas1-default-apps"
    app.kubernetes.io/version: "0.1.0"
    helm.sh/chart: "default-apps-openstack-0.1.0"
    giantswarm.io/cluster: "thomas1"
    giantswarm.io/organization: "multi-project"
    giantswarm.io/service-type: managed
  name: thomas1-net-exporter-user-values
  namespace: org-multi-project
data:
  values: |
    dns:
      service: kube-dns
```