### PR TITLE
Move to cluster-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ workflows:
       - architect/push-to-app-catalog:
           context: "architect"
           executor: "app-build-suite"
-          name: "package and push default-apps-openstack chart"
-          app_catalog: "giantswarm-catalog"
-          app_catalog_test: "giantswarm-test-catalog"
+          name: "push-to-app-catalog"
+          app_catalog: "cluster-catalog"
+          app_catalog_test: "cluster-test-catalog"
           chart: "default-apps-openstack"
           # Trigger job on git tag.
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.13.0
+  architect: giantswarm/architect@4.14.2
 
 workflows:
   package-and-push-chart-on-tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move app definitions to `values.yaml`.
+- Move from `giantswarm-catalog` to `cluster-catalog`.
 
 ## [0.1.1] - 2022-02-16
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21059

This PR:

- Moves the app from giantswarm-catalog to cluster-catalog.