### PR TITLE
Add giantswarm.io/managed-by label so apps are accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `giantswarm.io/managed-by` label so apps are accepted by `app-admission-controller`.
+
 ### Changed
 
 - Move from `giantswarm-catalog` to `cluster-catalog`.

--- a/helm/default-apps-openstack/templates/_helpers.tpl
+++ b/helm/default-apps-openstack/templates/_helpers.tpl
@@ -23,6 +23,7 @@ app.kubernetes.io/managed-by: {{ .Release.Name | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 giantswarm.io/cluster: {{ .Values.clusterName | quote }}
+giantswarm.io/managed-by: {{ .Release.Name | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
 giantswarm.io/service-type: managed
 {{- end -}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21038


This PR:

- Adds the managed by label to the child apps with the name of the parent app.

e.g. `giantswarm.io/managed-by: ross2-default-apps`

This means that app-admission-controller will accept them straightaway and there is no confusing `failed` status.

```

ross2-app-operator               5.7.5                                            2m5s         119s            deployed
ross2-calico                                                                      2m5s
ross2-cert-exporter                                                               2m5s
ross2-chart-operator                                                              2m3s
ross2-cloud-provider-openstack                                                    2m5s
ross2-cluster                    0.7.0                                            2m9s         2m6s            deployed
ross2-default-apps               0.2.0-69152ba9a26370e51b7cf3dc55597f7aa3e98de2   2m9s         2m6s            deployed
ross2-kube-state-metrics                                                          2m5s
ross2-metrics-server                                                              2m5s
ross2-net-exporter                                                                2m5s
ross2-node-exporter                                                               2m5s
```

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
