### PR TITLE
Bump cloud-provider-openstack version from 0.2.2 to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move from `giantswarm-catalog` to `cluster-catalog`.
+- Upgrade `cloud-provider-openstack` from v0.2.2 to v0.3.0.
 
 ## [0.2.0] - 2022-03-07
 

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -47,7 +47,7 @@ apps:
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.2.2
+    version: 0.3.0
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app


### PR DESCRIPTION
This PR:

- Bump cloud-provider-openstack version from 0.2.2 to 0.3.0

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
