### PR TITLE
Bump cloudProviderOpenstack to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `cloud-provider-openstack` to version `0.4.0`.
+
 ## [0.3.0] - 2022-03-30
 
 ### Added

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -47,7 +47,7 @@ apps:
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.2.2
+    version: 0.4.0
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources


### PR DESCRIPTION
This PR:

- Bumps cloudProviderOpenstack version from 0.2.2 to 0.4.0

### Testing

- [ ] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
