### PR TITLE
Disable Cilium network policies and remove cluster-resources

### DIFF
--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -55,9 +55,9 @@ apps:
     clusterValues:
       configMap: false
       secret: false
-    forceUpgrade: false
+    forceUpgrade: true
     namespace: kube-system
-    version: 0.1.0-0cc059b5bec05843672375220d5c7e0793b61015
+    version: 0.1.0-65995e7fdb7c1af72bf4dc2022f9ae211d8add40
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -3,6 +3,10 @@ organization: ""
 managementCluster: ""
 
 userConfig:
+  cilium:
+    configMap:
+      values: |
+        policyEnforcementMode: never
   cloudProviderOpenstack:
     configMap:
       values: |
@@ -48,16 +52,6 @@ apps:
     forceUpgrade: true
     namespace: kube-system
     version: 0.4.0
-  clusterResources:
-    appName: cluster-resources
-    chartName: cluster-resources
-    catalog: default-test
-    clusterValues:
-      configMap: false
-      secret: false
-    forceUpgrade: true
-    namespace: kube-system
-    version: 0.1.0-a904b9f6c455f1104b31d1907d8795a9728e2d6b
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -51,13 +51,13 @@ apps:
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources
-    catalog: default
+    catalog: default-test
     clusterValues:
       configMap: false
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    version: 0.1.0
+    version: 0.1.0-0cc059b5bec05843672375220d5c7e0793b61015
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -57,7 +57,7 @@ apps:
       secret: false
     forceUpgrade: true
     namespace: kube-system
-    version: 0.1.0-65995e7fdb7c1af72bf4dc2022f9ae211d8add40
+    version: 0.1.0-a904b9f6c455f1104b31d1907d8795a9728e2d6b
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app


### PR DESCRIPTION
This PR:

- Disables Cilium network policies
- Removes cluster-resources as a default app

This is a temporary change for the beta release. Both changes are to simplify dependencies when bootstrapping new MCs and WCs until we have a more reliable method for setting up network policies. The specific issue this solves is that `cluster-resources` can't create `CiliumNetworkPolicy` or `CiliumClusterWideNetworkPolicy` until `cilium-operator` has created these CRDs. This does eventually resolve due to chart-operator retries, but it has the potential to break cluster creation and should be solved in a more reliable way.

### Testing

- [x] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
