### PR TITLE
Consume node-exporter 1.11.0 to disable some collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `node-exporter` to version `1.11.0` and disable `nvme` and `conntrack` collectors that don't work with latest ubuntu images.
+
 ## [0.4.0] - 2022-04-01
 
 ### Changed

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -16,6 +16,11 @@ userConfig:
       values: |
         dns:
           service: kube-dns
+  nodeExporter:
+    configMap:
+      values: |
+        disableConntrackCollector: true
+        disableNvmeCollector: true
 
 apps:
   certExporter:
@@ -97,4 +102,4 @@ apps:
       secret: false
     forceUpgrade: true
     namespace: kube-system
-    version: 1.9.0
+    version: 1.11.0


### PR DESCRIPTION
This PR consumes this workaround: https://github.com/giantswarm/node-exporter-app/pull/136/files

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
