### PR TITLE
Enable volumesnapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `csi-external-snapshotter` app to be able to create volumesnapshots.
+- Upgrade `cloud-provider-openstack` to `0.5.0` to create default `volumesnapshotclass`. 
+
 ## [0.5.0] - 2022-04-07
 
 ### Changed

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -46,17 +46,27 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default
+    catalog: default-test
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.4.0
+    version: 0.4.0-63bca58769548f12db5bec601e0ff272055ed53c
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources
     catalog: default
+    clusterValues:
+      configMap: false
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    version: 0.1.0
+  csiExternalSnapshotter:
+    appName: csi-external-snapshotter
+    chartName: csi-external-snapshotter-app
+    catalog: default-test
     clusterValues:
       configMap: false
       secret: false

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -46,13 +46,13 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default-test
+    catalog: default
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.4.0-63bca58769548f12db5bec601e0ff272055ed53c
+    version: 0.5.0
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources
@@ -66,13 +66,13 @@ apps:
   csiExternalSnapshotter:
     appName: csi-external-snapshotter
     chartName: csi-external-snapshotter-app
-    catalog: default-test
+    catalog: default
     clusterValues:
       configMap: false
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    version: 0.0.0-62871489f7a8bfb736145e958e96fdc837af3799
+    version: 0.1.0
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -72,7 +72,7 @@ apps:
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    version: 0.1.0
+    version: 0.0.0-06d67bef51f03a671c73d44fcfd1e336a25e5f7d
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -72,7 +72,7 @@ apps:
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    version: 0.0.0-06d67bef51f03a671c73d44fcfd1e336a25e5f7d
+    version: 0.0.0-62871489f7a8bfb736145e958e96fdc837af3799
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app


### PR DESCRIPTION

- Add `csi-external-snapshotter` app to be able to create volumesnapshots.
- Upgrade `cloud-provider-openstack` to `0.5.0` to create default `volumesnapshotclass`. 

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
