### PR TITLE
Add cert-manager and csi webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `csi-external-snapshotter` app to be able to create volumesnapshots.
 - Upgrade `cloud-provider-openstack` to `0.5.0` to create default `volumesnapshotclass`. 
-- Add `cert-manager` app and update `csi-external-snapshotter` to use validating webhooks.
+- Add `cert-manager` app in order to use validating webhooks.
+
+### Changed
+
+- Upgrade `cloud-provider-openstack` to version `0.6.0`.
+- Upgrade `csi-external-snapshotter` to version `0.2.0`.
 
 ## [0.5.0] - 2022-04-07
 
 ### Changed
 
 - Upgrade `node-exporter` to version `1.11.0` and disable `nvme` and `conntrack` collectors that don't work with latest ubuntu images.
+- Upgrade `cloud-provider-openstack` to version `0.6.0`.
 
 ## [0.4.0] - 2022-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade `node-exporter` to version `1.11.0` and disable `nvme` and `conntrack` collectors that don't work with latest ubuntu images.
-- Upgrade `cloud-provider-openstack` to version `0.6.0`.
 
 ## [0.4.0] - 2022-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `csi-external-snapshotter` app to be able to create volumesnapshots.
 - Upgrade `cloud-provider-openstack` to `0.5.0` to create default `volumesnapshotclass`. 
+- Add `cert-manager` app and update `csi-external-snapshotter` to use validating webhooks.
 
 ## [0.5.0] - 2022-04-07
 

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -33,6 +33,16 @@ apps:
     forceUpgrade: true
     namespace: kube-system
     version: 2.1.0
+  certManager:
+    appName: cert-manager
+    chartName: cert-manager-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: true
+    namespace: kube-system
+    version: 2.13.0
   cilium:
     appName: cilium
     chartName: cilium
@@ -66,13 +76,13 @@ apps:
   csiExternalSnapshotter:
     appName: csi-external-snapshotter
     chartName: csi-external-snapshotter-app
-    catalog: default
+    catalog: default-test
     clusterValues:
       configMap: false
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    version: 0.1.0
+    version: 0.1.0-d74b674b26d2439fd40c34113acd78ace8e0ceb1
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -56,13 +56,13 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default-test
+    catalog: default
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.5.1-27001a0b668b3c34ee95d1773ae199f88cf662ad
+    version: 0.6.0
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources
@@ -76,13 +76,13 @@ apps:
   csiExternalSnapshotter:
     appName: csi-external-snapshotter
     chartName: csi-external-snapshotter-app
-    catalog: default-test
+    catalog: default
     clusterValues:
       configMap: false
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    version: 0.1.0-9e6b39bcf058ee234701e7a6b9930e20521a6f45
+    version: 0.2.0
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -56,13 +56,13 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default
+    catalog: default-test
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.5.0
+    version: 0.5.1-27001a0b668b3c34ee95d1773ae199f88cf662ad
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources
@@ -82,7 +82,7 @@ apps:
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    version: 0.1.0-d74b674b26d2439fd40c34113acd78ace8e0ceb1
+    version: 0.1.0-9e6b39bcf058ee234701e7a6b9930e20521a6f45
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app


### PR DESCRIPTION
This PR:

- Updates `csiExternalSnapshotter` version to use validating webhooks.
- Adds `cert-manager` to default apps to be able to provide certificates for webhook.

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
