### PR TITLE
Update cloud-provider-openstack-app to 0.6.1 for removed ca-certs mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update cloud-provider-openstack-app to 0.6.1 for removed ca-certs mount.
+
 ## [0.6.0] - 2022-05-23
 
 ### Added

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -56,13 +56,13 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default
+    catalog: default-test
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.6.0
+    version: 0.6.0-dc89747a1cb5239d15dbe497e879884e3ffa38b6
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -56,13 +56,13 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default-test
+    catalog: default
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.6.0-dc89747a1cb5239d15dbe497e879884e3ffa38b6
+    version: 0.6.1
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/778