### PR TITLE
Bump openstack-cloud-controller-version to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update kube-state-metrics to 1.11.0 to fix team label for monitoring purposes.
+- Bump `openstack-cloud-controller-manager` version to `0.6.2` to bring fixes.
 
 ## [0.6.1] - 2022-06-27
 

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -56,13 +56,13 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default
+    catalog: default-test
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.6.1
+    version: 0.6.1-f2c8d7d860b56746a03814a48de588a8af4a2c1b
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -56,13 +56,13 @@ apps:
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app
-    catalog: default-test
+    catalog: default
     clusterValues:
       configMap: true
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 0.6.1-f2c8d7d860b56746a03814a48de588a8af4a2c1b
+    version: 0.6.2
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources


### PR DESCRIPTION
Contains these two fixes:
- https://github.com/giantswarm/cloud-provider-openstack-app/pull/50
- https://github.com/giantswarm/cloud-provider-openstack-app/pull/49

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
