### PR TITLE
Bump versions of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `cert-exporter` from `2.1.0` to `2.2.0`.
+- Update `cert-manager-app` from `2.15.2` to `2.15.3`.
+- Update `cilium-app` from `0.1.0` to `0.2.6`.
+- Update `metrics-server-app` from `1.6.0` to `1.8.0`. 
+
 ## [0.6.4] - 2022-08-17
 
 ### Changed

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -58,7 +58,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cilium-app
-    version: 0.1.0
+    version: 0.2.6
   cloudProviderOpenstack:
     appName: cloud-provider-openstack
     chartName: cloud-provider-openstack-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -46,7 +46,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-manager-app
-    version: 2.15.2
+    version: 2.15.3
   cilium:
     appName: cilium
     chartName: cilium

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -34,7 +34,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-exporter
-    version: 2.1.0
+    version: 2.2.0
   certManager:
     appName: cert-manager
     chartName: cert-manager-app

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -118,7 +118,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/metrics-server-app
-    version: 1.6.0
+    version: 1.8.0
   netExporter:
     appName: net-exporter
     chartName: net-exporter


### PR DESCRIPTION
This PR contains changes in these PRs opened by `renovate`
- https://github.com/giantswarm/default-apps-openstack/pull/68
- https://github.com/giantswarm/default-apps-openstack/pull/69 
- https://github.com/giantswarm/default-apps-openstack/pull/70
- https://github.com/giantswarm/default-apps-openstack/pull/71

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
