### PR TITLE
Disable force upgrade for cert-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled force upgrade for `cert-manager`. It causes messed up installations because the initial install times out as there are usually no ready nodes in this case at that time. Forcing the upgrade possibly deletes an already running installation as Helm default timeout is 5 mins and `chart-operator` stops waiting for the status after 2 mins, leaving the install process running and marking the release as pending.
+
 ## [0.6.5] - 2022-09-19
 
 ### Changed

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -42,7 +42,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
-    forceUpgrade: true
+    forceUpgrade: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-manager-app


### PR DESCRIPTION
This PR:

- Disables force upgrade for `cert-manager`. It causes messed up installations because the initial install times out as there are usually no ready nodes in this case at that time. Forcing the upgrade possibly deletes an already running installation as Helm default timeout is 5 mins and `chart-operator` stops waiting for the status after 2 mins, leaving the install process running and marking the release as pending.

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
