### PR TITLE
net-exporter for coredns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Use `coredns.svc.kube-system` as monitoring target for `net-operator`
+
 ## [0.7.0] - 2022-09-19
 
 ### Added

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -11,11 +11,6 @@ userConfig:
         openstack-cloud-controller-manager:
           controllerExtraArgs: |-
             - --cluster-name=giant_swarm_cluster_{{ .Values.managementCluster }}_{{ .Values.clusterName }}
-  netExporter:
-    configMap:
-      values: |
-        dns:
-          service: kube-dns
   nodeExporter:
     configMap:
       values: |


### PR DESCRIPTION
net-exporter now uses coredns as service name in namespace kube-sytem as monitoring target

This PR:

- Adds/changes/removes...

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
