### PR TITLE
bump node-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `node-exporter-app` from `0.11.0` to `0.13.0`
+
 ## [0.7.3] - 2022-10-11
 
 ### Changed

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -157,4 +157,4 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/node-exporter-app
-    version: 1.11.0
+    version: 1.13.0


### PR DESCRIPTION
This PR:

Updates `node-exporter` to latest version. With this version we will get `diskstats` metrics which might help to understand/detect disk performance issues over AZs much more easier.
ATM we have to use some `etcd` metrics to get a better feeling if the storage might be slow on a special AZ.

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
