### PR TITLE
Add vertical-pod-autoscaler{-crd} to default apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `vertical-pod-autoscaler@2.5.3` & `vertical-pod-autoscaler-crd@1.0.1`.
+
 ### Changed
 
 - Update `node-exporter` to `1.15.0`

--- a/helm/default-apps-openstack/values.schema.json
+++ b/helm/default-apps-openstack/values.schema.json
@@ -481,3 +481,4 @@
         "managementCluster"
     ]
 }
+

--- a/helm/default-apps-openstack/values.yaml
+++ b/helm/default-apps-openstack/values.yaml
@@ -171,3 +171,27 @@ apps:
     # used by renovate
     # repo: giantswarm/observability-bundle
     version: 0.1.8
+  vpa:
+    appName: vertical-pod-autoscaler
+    chartName: vertical-pod-autoscaler-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/vertical-pod-autoscaler-app
+    version: 2.5.3
+  vpaCRD:
+    appName: vertical-pod-autoscaler-crd
+    chartName: vertical-pod-autoscaler-crd
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/vertical-pod-autoscaler-crd
+    version: 1.0.1


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/24783


This PR:

- Adds `vertical-pod-autoscaler` and `vertical-pod-autoscaler-crd`

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.
(no environment to test)

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
